### PR TITLE
So the subsequent child can be searched.

### DIFF
--- a/aimm_post_processing/client.py
+++ b/aimm_post_processing/client.py
@@ -57,8 +57,12 @@ def search_sets_in_child(
     """
 
     if isinstance(child_names, list):
-        child = tuple(child_names)
-    child_node = root[child]
+        child_names = tuple(child_names)
+    
+    # Search subsequent child nodes along the tree
+    child_node = root
+    for child in child_names:
+        child_node = child_node[child]
 
     if search_symbol is None and search_edge is None:
         return child_node


### PR DESCRIPTION
`child = ["NCM", "BM_NCMA"]` was seen as a single child, now it is treated subsequent childs.