### PR TITLE
Add Identity operator

### DIFF
--- a/aimm_post_processing/operations.py
+++ b/aimm_post_processing/operations.py
@@ -1,0 +1,49 @@
+"""Module for housing postprocessing operations."""
+
+from datetime import datetime
+
+from monty.json import MSONable
+
+
+class Operator(MSONable):
+    """Base operator class. Tracks everything required through a combination
+    of the MSONable base class and by using an additional datetime key to track
+    when the operator was logged into the metadata of a new node.
+
+    .. important::
+
+        The __call__ method must be derived for every operator. In particular,
+        this operator should take as arguments at least one other data point
+        (node).
+    """
+
+    def as_dict(self):
+        d = super().as_dict()
+        d["datetime"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        return d
+
+    @classmethod
+    def from_dict(cls, d):
+        if "datetime" in d.keys():
+            d.pop("datetime")
+        return super().from_dict(d)
+
+    def __call__(self):
+        raise NotImplementedError
+
+
+class Identity(Operator):
+    """The identity operation. Does nothing. Used for testing purposes."""
+
+    def __call__(self, x):
+        """
+        Parameters
+        ----------
+        x : tiled.client.dataframe.DataFrameClient
+        """
+
+        # Note this will throw a TypeError, as setting attributes is not
+        # allowed!
+        x.metadata["derived"] = {**self.as_dict(), "parents": [x.uri]}
+
+        return x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-# List required packages in this file, one per line.
+monty


### PR DESCRIPTION
I've added the scaffold for post-processing operators. Does everyone like the style I've implemented here? Note that the `__call__` method will not actually work, since `x.metadata` is immutable in the current way that the nodes work.

Thoughts? Please don't merge until we've discussed a bit!

Note while this might seem trivial these types of design decisions are super important early on and will influence everything downstream. So even though the `Identity` operator is hilariously simple it's really important we get the metadata tracking correct now. Also I know that Joe will likely be making some more API changes as per our discussion today, but I don't think it will impact the high-level discussion.